### PR TITLE
fix(terragrunt): bump tg_version and tofu_version for OpenTofu 1.11 compatibility

### DIFF
--- a/terragrunt/action.yaml
+++ b/terragrunt/action.yaml
@@ -82,8 +82,8 @@ runs:
       id: terragrunt
       uses: gruntwork-io/terragrunt-action@v3.2.0
       with:
-        tg_version: '0.83.2'
-        tofu_version: '1.6.0'
+        tg_version: '1.0.2'
+        tofu_version: '1.11.6'
         tg_dir: ${{ inputs.working-directory }}
         tg_command: ${{ inputs.action-type }}
         tg_add_approve: ${{ inputs.action-type == 'apply' && '1' || '' }}


### PR DESCRIPTION
## Summary
- `terragrunt/action.yaml` の `tg_version` を `0.83.2` → `1.0.2`、`tofu_version` を `1.6.0` → `1.11.6` に更新
- panicboat/platform 側のモジュールが `required_version = ">= 1.11.6"` を要求しており、現状の OpenTofu 1.6.0 では `tofu init` が以下のエラーで失敗していた:

  ```
  Error: Unsupported OpenTofu Core version
  This configuration does not support OpenTofu version 1.6.0.
  ```

## Why bump tg_version too

[Terragrunt の公式互換性マトリクス](https://docs.terragrunt.com/reference/supported-versions) では OpenTofu 1.11.x は **Terragrunt >= 0.95.0** を要求している。現状の `0.83.2` は OpenTofu 1.10.x までしかサポート対象外なので、両者を同時に上げる必要がある。

| OpenTofu | 必要 Terragrunt |
|---|---|
| 1.11.x | >= 0.95.0 |
| 1.10.x | >= 0.82.0 |

## Scope
- 単発の bump 対応のみ。Renovate の customManager 追加（`tofu_version` / `tg_version` の自動追従）は別 PR で対応予定

## Test plan
- [ ] この PR マージ後、panicboat/platform#201 を再実行し、`github/repository` の terragrunt plan が通ることを確認
- [ ] 既存 AWS スタック（`aws/vpc`, `aws/github-oidc-auth`）の plan に想定外の差分が出ないことを確認（Terragrunt 0.83 → 1.0 のメジャー跨ぎ影響の有無）

## Risks
Terragrunt 0.83 → 1.0 はメジャーバージョン跨ぎ。破壊的変更を踏む可能性があるため、マージ後は AWS 側の既存 PR / 次の plan 実行で差分・エラーがないか監視する。問題があれば Revert か段階的ダウングレード。