### PR TITLE
chore(renovate): track tofu_version and tg_version in terragrunt action.yaml

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -44,5 +44,30 @@
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true
     }
+  ],
+
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track OpenTofu version pinned in terragrunt composite action",
+      "fileMatch": ["^terragrunt/action\\.yaml$"],
+      "matchStrings": [
+        "tofu_version:\\s*['\"](?<currentValue>[^'\"]+)['\"]"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "opentofu/opentofu",
+      "extractVersionTemplate": "^v?(?<version>.+)$"
+    },
+    {
+      "customType": "regex",
+      "description": "Track Terragrunt version pinned in terragrunt composite action",
+      "fileMatch": ["^terragrunt/action\\.yaml$"],
+      "matchStrings": [
+        "tg_version:\\s*['\"](?<currentValue>[^'\"]+)['\"]"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "gruntwork-io/terragrunt",
+      "extractVersionTemplate": "^v?(?<version>.+)$"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- `.github/renovate.json` に `customManagers`（regex）を追加し、`terragrunt/action.yaml` の `tofu_version` / `tg_version` リテラルをそれぞれ `opentofu/opentofu` / `gruntwork-io/terragrunt` の GitHub Releases に紐付ける
- 以後、新しい OpenTofu / Terragrunt リリース時に Renovate が自動で PR を作成するようになる

## Why
- Renovate の `github-actions` マネージャは `uses:` のアクション参照（例: `gruntwork-io/terragrunt-action@v3.2.0`）は追跡するが、`with:` で渡す入力値の中身は依存として認識しない
- そのためこれまで `tofu_version: '1.6.0'` と `tg_version: '0.83.2'` がハードコードのまま取り残され、panicboat/platform の `required_version = ">= 1.11.6"` と乖離して CI が 1 度破綻した（#197 で手動 bump 済み）
- regex customManager で明示的に「これは opentofu/terragrunt のバージョン」と教えてあげることで、同種のドリフトを自動修正できるようにする

## Details
```json
{
  "customType": "regex",
  "fileMatch": ["^terragrunt/action\\.yaml$"],
  "matchStrings": ["tofu_version:\\s*['\"](?<currentValue>[^'\"]+)['\"]"],
  "datasourceTemplate": "github-releases",
  "depNameTemplate": "opentofu/opentofu",
  "extractVersionTemplate": "^v?(?<version>.+)$"
}
```

`tg_version` 側も同様。`extractVersionTemplate` で先頭の `v` を剥がし、action.yaml 内の書式（`'1.11.6'`）に揃える。

## Test plan
- [ ] マージ後、Renovate のスケジュール（`before 4am every weekday`）で initial scan が走り、`terragrunt/action.yaml` の 2 つの値が現行最新と一致していれば PR は出ない（現在 `tofu_version: 1.11.6`, `tg_version: 1.0.2` でいずれも最新）
- [ ] 将来 OpenTofu 1.11.7 などがリリースされた際に、この PR の customManager 経由で bump PR が自動生成されることを確認

## Notes
- `extends` に `config:base` を使っているため、customManagers の評価はそのまま有効
- Renovate の minor/patch 自動マージルール（既存 packageRules）はそのまま適用されるので、OpenTofu/Terragrunt の minor/patch bump は自動マージ候補になる