### PR TITLE
fix(terragrunt): remove continue-on-error from Execute Terragrunt step

### DIFF
--- a/terragrunt/action.yaml
+++ b/terragrunt/action.yaml
@@ -115,7 +115,7 @@ runs:
           });
 
     - name: Comment PR with Terragrunt results
-      if: inputs.pr-number != ''
+      if: always() && inputs.pr-number != ''
       uses: thollander/actions-comment-pull-request@v3.0.1
       with:
         message: |

--- a/terragrunt/action.yaml
+++ b/terragrunt/action.yaml
@@ -88,7 +88,6 @@ runs:
         tg_command: ${{ inputs.action-type }}
         tg_add_approve: ${{ inputs.action-type == 'apply' && '1' || '' }}
         github_token: ${{ inputs.github-token }}
-      continue-on-error: true
       env:
         TF_INPUT: false
         GITHUB_TOKEN: ${{ inputs.github-token }}


### PR DESCRIPTION
## Summary

- `terragrunt/action.yaml` の `Execute Terragrunt` ステップから `continue-on-error: true` を削除
- 合わせて `Comment PR with Terragrunt results` ステップに `if: always()` を追加し、失敗時も PR への結果コメントを維持
- これにより terragrunt の `apply`/`plan` が失敗したときにジョブが正しく失敗としてマークされつつ、PR への失敗通知コメントも残るようになる

## Background

`panicboat/platform` の apply 実行で `PATCH https://api.github.com/repos/... 403 Resource not accessible by integration` により `tofu apply` が exit 1 で落ちたにもかかわらず、GitHub Actions 上は緑（success）表示になる事象が発生した ([例](https://github.com/panicboat/platform/actions/runs/24851168807/job/72751744121))。

原因は以下の 2 点の組み合わせ:

1. `Execute Terragrunt` ステップに `continue-on-error: true` が付いており、terragrunt の exit 1 が握りつぶされる
2. 後続の `Parse execution results` (`parse-results.js`) は `is-failed=true` / `status=❌ Failed` を output に設定するだけで `core.setFailed()` を呼ばない

結果、`Status: ❌ Failed (exit code: 1)` と表示されているのに job は success で終わる。

## Rationale

当初 `continue-on-error: true` を入れた理由は「差分がない plan で失敗マークされる事象を回避するため」と認識していたが、`gruntwork-io/terragrunt-action@v3.2.0` の実装 (`src/main.sh`) を確認したところ、terragrunt の exit code をそのまま透過するだけで独自の挙動はなく、`terragrunt plan` は `-detailed-exitcode` 未指定時は diff があっても 0 を返すため、差分有無で exit code が変わる余地がない。つまり当初の懸念は現状の組み合わせでは発生しないため、握りつぶしは不要。

また、`continue-on-error: true` 削除の副作用として、失敗時に後続の PR コメントステップがスキップされて PR 通知が消えてしまう問題があるため、コメントステップ側に `if: always()` を入れて失敗時も投稿を継続させる。

## Test plan

- [ ] この PR をマージ後、`panicboat/platform` 側で意図的に失敗する terragrunt apply を走らせ、ジョブが赤マークされ、かつ PR に `❌ Failed` コメントが投稿されることを確認
- [ ] 正常系 (plan 成功 / apply 成功) が引き続き成功マークされ、PR に成功コメントが投稿されることを確認