### PR TITLE
fix(validate_config): skip required check for undeclared stacks

### DIFF
--- a/action-scripts/config-manager/use_cases/validate_config.rb
+++ b/action-scripts/config-manager/use_cases/validate_config.rb
@@ -79,7 +79,10 @@ module UseCases
             required = stack_def['required_attributes'] || []
             next if required.empty?
 
-            stack_attrs = env_config.dig('stacks', stack_name) || {}
+            # Skip when the environment does not declare this stack — it opts out of the stack
+            stack_attrs = env_config.dig('stacks', stack_name)
+            next if stack_attrs.nil?
+
             required.each do |attr|
               unless stack_attrs.key?(attr)
                 errors << "Environment '#{env_name}' missing required attribute for stack '#{stack_name}': #{attr}"

--- a/action-scripts/spec/config-manager/use_cases/validate_config_spec.rb
+++ b/action-scripts/spec/config-manager/use_cases/validate_config_spec.rb
@@ -215,6 +215,48 @@ RSpec.describe UseCases::ConfigManagement::ValidateConfig do
         expect(result).to be_success
       end
     end
+
+    context 'when stack is not declared in environment.stacks' do
+      let(:config_hash) do
+        {
+          'environments' => [
+            {
+              'environment' => 'local',
+              'stacks' => {
+                'kubernetes' => {}
+              }
+            }
+          ],
+          'stack_conventions' => [
+            {
+              'root' => '{service}',
+              'stacks' => [
+                {
+                  'name' => 'terragrunt',
+                  'directory' => 'terragrunt/{environment}',
+                  'required_attributes' => ['aws_region', 'iam_role_plan', 'iam_role_apply']
+                },
+                {
+                  'name' => 'kubernetes',
+                  'directory' => 'kubernetes/overlays/{environment}'
+                }
+              ]
+            }
+          ],
+          'services' => []
+        }
+      end
+      let(:config) { Entities::WorkflowConfig.new(config_hash) }
+
+      before do
+        allow(config_client).to receive(:load_workflow_config).and_return(config)
+      end
+
+      it 'skips required_attributes validation for the undeclared stack' do
+        result = use_case.execute
+        expect(result).to be_success
+      end
+    end
   end
 
   describe 'integration with real config client' do


### PR DESCRIPTION
## Summary

`UseCases::ConfigManagement::ValidateConfig#validate_environment_config` を修正し、`environments[].stacks.<stack_name>` が未宣言の場合は当該 stack の `required_attributes` 検証をスキップするようにした。

これにより「local 環境では terragrunt を使わない」のような構成を `stacks.terragrunt` の省略で表現できるようになる。従来は required_attributes キー全件不足エラーが出るため空文字 placeholder を入れて回避する必要があった。

## Behavior change

- **未宣言 (`stacks.terragrunt` なし)**: required_attributes 検証をスキップ（新挙動）
- **空 hash 宣言 (`stacks.terragrunt: {}`)**: required_attributes キー存在チェックを行う（従来通り）

「stack を使うが値はない」と「stack を使わない」を区別できる。

## Test plan

- [x] `bundle exec rspec` で 213 examples / 0 failures（新規 context 1 件追加）
- [ ] `panicboat/platform` の `workflow-config.yaml` から local 環境の terragrunt placeholder を削除した PR が valid と判定される