### PR TITLE
feat(label-resolver): match all stack conventions for multi-stack services

### DIFF
--- a/action-scripts/label-resolver/use_cases/generated_matrix.rb
+++ b/action-scripts/label-resolver/use_cases/generated_matrix.rb
@@ -69,11 +69,15 @@ module UseCases
       def generate_targets_for_service(deploy_label, config)
         targets = []
 
-        # Get all available stacks from the first matching convention only
-        matching_convention = find_matching_convention(deploy_label.service, config)
-        return targets unless matching_convention
+        # A service can legitimately span multiple conventions (e.g. aws/{service} for
+        # terragrunt + kubernetes/components/{service} for kubernetes manifests).
+        # Collect stacks from every matching convention; dedup by stack name (first wins)
+        # so duplicate stack names across conventions don't multiply targets — downstream
+        # lookup is keyed on stack name and converges to the same working directory.
+        matching_conventions = find_matching_conventions(deploy_label.service, config)
+        return targets if matching_conventions.empty?
 
-        stacks = matching_convention['stacks'] || []
+        stacks = matching_conventions.flat_map { |c| c['stacks'] || [] }.uniq { |s| s['name'] }
 
         stacks.each do |stack_config|
           stack_name = stack_config['name']
@@ -112,20 +116,17 @@ module UseCases
         targets
       end
 
-      # Find the first matching convention that has existing directories for this service
-      def find_matching_convention(service_name, config)
+      # Find every convention that has existing directories for this service.
+      # Returns conventions in declaration order so callers can rely on first-wins dedup
+      # for stack names that appear in more than one convention.
+      def find_matching_conventions(service_name, config)
         repo_root = find_repository_root
 
-        config.stack_conventions_config.each do |convention|
-          # Check if any stack in this convention has existing directories for this service
+        config.stack_conventions_config.select do |convention|
           stacks = convention['stacks'] || []
 
-          has_existing_directory = stacks.any? do |stack_config|
-            stack_name = stack_config['name']
-
-            # Check across all target environments
+          stacks.any? do |stack_config|
             @target_environments.any? do |env|
-              # Build the pattern for this convention
               root_pattern = convention['root']
               stack_directory = stack_config['directory']
 
@@ -135,23 +136,15 @@ module UseCases
                               "#{root_pattern}/#{stack_directory}"
                             end
 
-              # Expand placeholders
               expanded_pattern = full_pattern.gsub('{service}', service_name)
-              # Only expand {environment} placeholder if present
               if full_pattern.include?('{environment}')
                 expanded_pattern = expanded_pattern.gsub('{environment}', env)
               end
 
-              # Check if directory exists
-              full_path = File.join(repo_root, expanded_pattern)
-              File.directory?(full_path)
+              File.directory?(File.join(repo_root, expanded_pattern))
             end
           end
-
-          return convention if has_existing_directory
         end
-
-        nil
       end
 
       # Check if stack directory exists for service/environment combination

--- a/action-scripts/spec/label-resolver/use_cases/generate_matrix_spec.rb
+++ b/action-scripts/spec/label-resolver/use_cases/generate_matrix_spec.rb
@@ -354,7 +354,7 @@ RSpec.describe UseCases::LabelResolver::GenerateMatrix do
         allow(config).to receive(:stack_attributes_for).with('production', 'kubernetes').and_return({})
         allow(config).to receive(:stack_attributes_for).with(anything, 'docker').and_return({})
 
-        # Mock stack_conventions_config for find_matching_convention
+        # Mock stack_conventions_config for find_matching_conventions
         allow(config).to receive(:stack_conventions_config).and_return([
           {
             'root' => '{service}',
@@ -399,6 +399,122 @@ RSpec.describe UseCases::LabelResolver::GenerateMatrix do
 
         # Total: 1 docker + 3 terragrunt + 3 kubernetes = 7 targets
         expect(result.deployment_targets.length).to eq(7)
+      end
+    end
+
+    context 'with service spanning multiple stack conventions' do
+      let(:target_environments) { ['production'] }
+      let(:env_config) do
+        {
+          'environment' => 'production',
+          'stacks' => {
+            'terragrunt' => {
+              'aws_region' => 'ap-northeast-1',
+              'iam_role_plan' => 'arn:aws:iam::123456789012:role/plan-role',
+              'iam_role_apply' => 'arn:aws:iam::123456789012:role/apply-role'
+            },
+            'kubernetes' => {}
+          }
+        }
+      end
+
+      before do
+        allow(config).to receive(:environment_config).with('production').and_return(env_config)
+        allow(config).to receive(:stack_attributes_for).with('production', 'terragrunt').and_return(env_config['stacks']['terragrunt'])
+        allow(config).to receive(:stack_attributes_for).with('production', 'kubernetes').and_return({})
+        allow(config).to receive(:services).and_return({ 'test-service' => {} })
+
+        # Two separate conventions, each contributing a different stack
+        allow(config).to receive(:stack_conventions_config).and_return([
+          {
+            'root' => 'aws/{service}',
+            'stacks' => [
+              { 'name' => 'terragrunt', 'directory' => 'envs/{environment}' }
+            ]
+          },
+          {
+            'root' => 'kubernetes/components/{service}',
+            'stacks' => [
+              { 'name' => 'kubernetes', 'directory' => '{environment}' }
+            ]
+          }
+        ])
+
+        allow(config).to receive(:stack_conventions_for).with('test-service', 'terragrunt').and_return(['aws/test-service/envs/{environment}'])
+        allow(config).to receive(:stack_conventions_for).with('test-service', 'kubernetes').and_return(['kubernetes/components/test-service/{environment}'])
+
+        allow(File).to receive(:directory?).and_return(true)
+      end
+
+      it 'generates targets from every matching convention, not just the first' do
+        result = use_case.execute(deploy_labels: deploy_labels, target_environments: target_environments)
+
+        expect(result).to be_success
+        expect(result.deployment_targets.length).to eq(2)
+
+        terragrunt_target = result.deployment_targets.find { |t| t.stack == 'terragrunt' }
+        kubernetes_target = result.deployment_targets.find { |t| t.stack == 'kubernetes' }
+
+        expect(terragrunt_target).not_to be_nil
+        expect(terragrunt_target.working_directory).to eq('aws/test-service/envs/production')
+        expect(terragrunt_target.stack_convention_root).to eq('aws/test-service')
+
+        expect(kubernetes_target).not_to be_nil
+        expect(kubernetes_target.working_directory).to eq('kubernetes/components/test-service/production')
+        expect(kubernetes_target.stack_convention_root).to eq('kubernetes/components/test-service')
+      end
+    end
+
+    context 'with same stack name in multiple matching conventions' do
+      let(:target_environments) { ['production'] }
+      let(:env_config) do
+        {
+          'environment' => 'production',
+          'stacks' => {
+            'terragrunt' => {
+              'aws_region' => 'ap-northeast-1',
+              'iam_role_plan' => 'arn:aws:iam::123456789012:role/plan-role',
+              'iam_role_apply' => 'arn:aws:iam::123456789012:role/apply-role'
+            }
+          }
+        }
+      end
+
+      before do
+        allow(config).to receive(:environment_config).with('production').and_return(env_config)
+        allow(config).to receive(:stack_attributes_for).with('production', 'terragrunt').and_return(env_config['stacks']['terragrunt'])
+        allow(config).to receive(:services).and_return({ 'test-service' => {} })
+
+        # Two conventions, both contributing terragrunt — first one wins
+        allow(config).to receive(:stack_conventions_config).and_return([
+          {
+            'root' => 'aws/{service}',
+            'stacks' => [
+              { 'name' => 'terragrunt', 'directory' => 'envs/{environment}' }
+            ]
+          },
+          {
+            'root' => 'github/{service}',
+            'stacks' => [
+              { 'name' => 'terragrunt', 'directory' => 'envs/{environment}' }
+            ]
+          }
+        ])
+
+        allow(config).to receive(:stack_conventions_for).with('test-service', 'terragrunt').and_return([
+          'aws/test-service/envs/{environment}',
+          'github/test-service/envs/{environment}'
+        ])
+
+        allow(File).to receive(:directory?).and_return(true)
+      end
+
+      it 'dedupes by stack name and generates a single terragrunt target' do
+        result = use_case.execute(deploy_labels: deploy_labels, target_environments: target_environments)
+
+        expect(result).to be_success
+        expect(result.deployment_targets.length).to eq(1)
+        expect(result.deployment_targets.first.stack).to eq('terragrunt')
       end
     end
   end


### PR DESCRIPTION
## Summary

- A service can now span multiple `stack_conventions` entries. The resolver collects stacks from **every** matching convention instead of returning only the first match.
- Stack names duplicated across conventions are deduped (first wins), so existing single-convention services keep identical behavior.

## Why

`find_matching_convention` returned the first convention whose directory exists for a service. When a service has resources under both `aws/{service}` (terragrunt) and `kubernetes/components/{service}` (kubernetes), only the first convention's stacks were generated; the rest were silently skipped by downstream Group/Hydrate/Deploy Kubernetes jobs.

Real-world reproduction: panicboat/platform PR #273 (karpenter migration). Workflow run: https://github.com/panicboat/platform/actions/runs/25329718268

- Before: `karpenter:production:terragrunt` only — Kubernetes jobs all skipped.
- After: `karpenter:production:terragrunt` + `karpenter:production:kubernetes`.

## Test plan

- [x] RSpec: 215 examples, 0 failures (full suite)
- [x] New spec: multi-convention service generates one target per stack
- [x] New spec: same stack name across multiple conventions dedupes to one target
- [x] End-to-end: `bin/resolver debug 273 production` against panicboat/platform local checkout
  - main branch (unfixed): 1 target — bug reproduced
  - this branch (fixed): 2 targets including `kubernetes/components/karpenter/production`