### PR TITLE
chore(action-scripts): remove redundant empty stack declarations

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -78,7 +78,6 @@ environments:
         aws_region: ap-northeast-1
         iam_role_plan: arn:aws:iam::ACCOUNT:role/plan-role
         iam_role_apply: arn:aws:iam::ACCOUNT:role/apply-role
-      kubernetes: {}
 
 stack_conventions:
   - root: "{service}"

--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ environments:
         aws_region: ap-northeast-1
         iam_role_plan: arn:aws:iam::ACCOUNT:role/plan-role
         iam_role_apply: arn:aws:iam::ACCOUNT:role/apply-role
-      kubernetes: {}
 
 stack_conventions:
   - root: "{service}"

--- a/action-scripts/config-manager/controllers/config_manager_controller.rb
+++ b/action-scripts/config-manager/controllers/config_manager_controller.rb
@@ -179,7 +179,6 @@ module Interfaces
                   aws_region: ap-northeast-1
                   iam_role_plan: arn:aws:iam::ACCOUNT_ID:role/github-oidc-auth-develop-plan-role
                   iam_role_apply: arn:aws:iam::ACCOUNT_ID:role/github-oidc-auth-develop-apply-role
-                kubernetes: {}
 
             - environment: staging
               stacks:
@@ -187,7 +186,6 @@ module Interfaces
                   aws_region: ap-northeast-1
                   iam_role_plan: arn:aws:iam::ACCOUNT_ID:role/github-oidc-auth-staging-plan-role
                   iam_role_apply: arn:aws:iam::ACCOUNT_ID:role/github-oidc-auth-staging-apply-role
-                kubernetes: {}
 
             - environment: production
               stacks:
@@ -195,7 +193,6 @@ module Interfaces
                   aws_region: ap-northeast-1
                   iam_role_plan: arn:aws:iam::ACCOUNT_ID:role/github-oidc-auth-production-plan-role
                   iam_role_apply: arn:aws:iam::ACCOUNT_ID:role/github-oidc-auth-production-apply-role
-                kubernetes: {}
 
           stack_conventions:
             - root: "{service}"

--- a/action-scripts/workflow-config.yaml
+++ b/action-scripts/workflow-config.yaml
@@ -5,7 +5,6 @@ environments:
         aws_region: ap-northeast-1
         iam_role_plan: arn:aws:iam::123456789012:role/terragrunt-plan-develop-role
         iam_role_apply: arn:aws:iam::123456789012:role/terragrunt-apply-develop-role
-      kubernetes: {}
 
   - environment: staging
     stacks:


### PR DESCRIPTION
## What

Remove `kubernetes: {}` from `environments[].stacks` in:

- `action-scripts/workflow-config.yaml` (sample config)
- `action-scripts/config-manager/controllers/config_manager_controller.rb` (`build_config_template` output)
- `README.md` / `README-ja.md` (`## Configuration` example)

## Why

The empty declaration is equivalent to omitting the key entirely:

- `WorkflowConfig#stack_attributes_for` returns `{}` whether the stack key exists with an empty hash or is absent (the spec at `spec/shared/entities/workflow_config_spec.rb:156-162` covers both cases).
- `validate_config.rb` enforces `required_attributes` only on stacks that declare them; `kubernetes` declares none, so the empty hash is a no-op.
- Matrix generation reads `stack_conventions`, not `environments[].stacks`, and gates targets on directory existence.

Aligning the sample config / README / template with the leanest valid form makes the user-facing surface less misleading.

## What is intentionally not changed

`spec/spec_helper.rb#default_test_config` keeps `kubernetes: {}` so that `workflow_config_spec.rb` ("returns empty hash for stack defined as empty hash") continues to exercise that branch explicitly.

## Verification

- YAML parses cleanly.
- Logical equivalent of `validate_config.rb` passes for the updated sample (terragrunt `required_attributes` still declared on develop / staging / production).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified configuration examples by removing empty Kubernetes placeholders, providing clearer and more practical setup guidance.

* **Chores**
  * Cleaned up workflow configuration by removing unused Kubernetes stack placeholder entries from development, staging, and production environments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/panicboat/deploy-actions/pull/224)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->